### PR TITLE
Fixed raceID for Pandarens in playercreateinfo_spell

### DIFF
--- a/sql/updates/world/2014_05_04_00_world_playercreateinfo_spell.sql
+++ b/sql/updates/world/2014_05_04_00_world_playercreateinfo_spell.sql
@@ -1,0 +1,1 @@
+UPDATE `playercreateinfo_spell` SET `racemask` = 16777216 WHERE `racemask` = 24;


### PR DESCRIPTION
I finally fixed an annoying bug which fucked up the spell tree for Night Elf\Undead Rogues as you can see here: https://github.com/ProjectSkyfire/SkyFire_5xx/issues/141
raceID in playercreateinfo_spell follows the power of 2 and obviously 24 is NOT a power of 2 but the correct value is 2^24 = 16777216
