### PR TITLE
Core/Script: OnQuestAccept() it's triggered by Player::AddQuest() now.

### DIFF
--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -15698,6 +15698,27 @@ void Player::AddQuest(Quest const* quest, Object* questGiver)
     StartTimedAchievement(ACHIEVEMENT_TIMED_TYPE_QUEST, quest_id);
 
     UpdateForQuestWorldObjects();
+    if (questGiver) // script managment for every quest
+    {
+        switch (questGiver->GetTypeId())
+        {
+            case TYPEID_UNIT:
+                sScriptMgr->OnQuestAccept(this, (questGiver->ToCreature()), quest);
+                break;
+            case TYPEID_ITEM:
+            case TYPEID_CONTAINER:
+                {
+                    Item* item = (Item*)questGiver;
+                    sScriptMgr->OnQuestAccept(this, item, quest);
+                    break;
+                }
+            case TYPEID_GAMEOBJECT:
+                sScriptMgr->OnQuestAccept(this, questGiver->ToGameObject(), quest);
+                break;
+            default:
+                break;
+        }
+    }
 }
 
 void Player::CompleteQuest(uint32 quest_id)

--- a/src/server/game/Handlers/QuestHandler.cpp
+++ b/src/server/game/Handlers/QuestHandler.cpp
@@ -262,14 +262,12 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPacket& recvData)
             switch (object->GetTypeId())
             {
             case TYPEID_UNIT:
-                sScriptMgr->OnQuestAccept(_player, (object->ToCreature()), quest);
                 object->ToCreature()->AI()->sQuestAccept(_player, quest);
                 break;
             case TYPEID_ITEM:
             case TYPEID_CONTAINER:
                 {
                     Item* item = (Item*)object;
-                    sScriptMgr->OnQuestAccept(_player, item, quest);
 
                     // destroy not required for quest finish quest starting item
                     bool destroyItem = true;
@@ -288,7 +286,6 @@ void WorldSession::HandleQuestgiverAcceptQuestOpcode(WorldPacket& recvData)
                     break;
                 }
             case TYPEID_GAMEOBJECT:
-                sScriptMgr->OnQuestAccept(_player, object->ToGameObject(), quest);
                 object->ToGameObject()->AI()->QuestAccept(_player, quest);
                 break;
             default:


### PR DESCRIPTION
Small description:
This patch repair the situation where quest got auto-complete flag then creaturescript(c++ one) OnQuestAccept() it's skipped.
- the same situation is for quest-chains if next quest got auto-complete then OnQuestAccept() it's skipped.
- Also include quests where source is gameobject.
