### PR TITLE
Fix unused return value warning for chdir()

### DIFF
--- a/src/tools/map_extractor/System.cpp
+++ b/src/tools/map_extractor/System.cpp
@@ -143,14 +143,13 @@ void CreateDir(std::string const& path)
     if (chdir(path.c_str()) == 0)
     {
             chdir("../");
-            return;
-    }
-
+    } else {
 #ifdef _WIN32
-    _mkdir(path.c_str());
+        _mkdir(path.c_str());
 #else
-    mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IRWXO); // 0777
+        mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IRWXO); // 0777
 #endif
+    }
 }
 
 bool FileExists(TCHAR const* fileName)


### PR DESCRIPTION
It is good practice to not use void returns these days ;)

SkyFire_5xx/src/tools/map_extractor/System.cpp: In function â€˜void CreateDir(const string&)â€™:
SkyFire_5xx/src/tools/map_extractor/System.cpp:145:25: warning: ignoring return value of â€˜int chdir(const char*)â€™, declared with attribute warn_unused_result [-Wunused-result]
