### PR TITLE
CMAKE/FindOpenSSL.cmake

### DIFF
--- a/cmake/macros/FindOpenSSL.cmake
+++ b/cmake/macros/FindOpenSSL.cmake
@@ -197,7 +197,7 @@ if (OPENSSL_INCLUDE_DIR)
     set(OPENSSL_VERSION "${_OPENSSL_VERSION}")
   else (_OPENSSL_VERSION)
     file(STRINGS "${OPENSSL_INCLUDE_DIR}/openssl/opensslv.h" openssl_version_str
-         REGEX "^#define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9][0-9][0-9][0-9].*")
+         REGEX "^.*define[\t ]+OPENSSL_VERSION_NUMBER[\t ]+0x[0-9][0-9][0-9][0-9][0-9][0-9].*")
 
     # The version number is encoded as 0xMNNFFPPS: major minor fix patch status
     # The status gives if this is a developer or prerelease and is ignored here.


### PR DESCRIPTION
Updated Regex to Support space introduced in the name in Ver 1.0.2

ref:http://www.ownedcore.com/forums/world-of-warcraft/world-of-warcraft-emulator-servers/wow-emu-questions-requests/513039-openssl-cmake-problem-ubuntu-server.html

Tested with CMake Version 1.0.2
Needs to be tested with version 0.x