### PR TITLE
Scripts/Spells: Stampeding Roar, Dash

### DIFF
--- a/sql/updates/world/2022_06_22_00_world.sql
+++ b/sql/updates/world/2022_06_22_00_world.sql
@@ -1,0 +1,2 @@
+DELETE FROM `spell_script_names` WHERE `spell_id`=77764 AND `ScriptName`='spell_dru_stampeding_roar';
+INSERT INTO `spell_script_names` (`spell_id`, `ScriptName`) VALUES (77764, 'spell_dru_stampeding_roar');


### PR DESCRIPTION
- Druids under the effect of Dash no longer gain the Stampeding Roar buff from other Druids.
- Skull Bash properly charges the enemy.