### PR TITLE
Fix windows compile error

### DIFF
--- a/dep/StormLib/src/zlib/inffast.c
+++ b/dep/StormLib/src/zlib/inffast.c
@@ -102,7 +102,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
         if (bits < 15) {
             hold += (unsigned long)(*in++) << bits;
             bits += 8;
-            hold += (unsigned long)(*in++)) << bits;
+            hold += (unsigned long)(*in++) << bits;
             bits += 8;
         }
         here = lcode[hold & lmask];


### PR DESCRIPTION
Cherry-pick of commit 7ff5063 to fix Windows compile error in dep/StormLib/src/zlib/inffast.c