### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/dep/StormLib/src/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
+++ b/dep/StormLib/src/libtomcrypt/src/pk/rsa/rsa_verify_hash.c
@@ -96,7 +96,7 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
   } else {
     /* LTC_PKCS #1 v1.5 decode it */
     unsigned char *out;
-    unsigned long outlen, loid[16];
+    unsigned long outlen, loid[16], reallen;
     int           decoded;
     ltc_asn1_list digestinfo[2], siginfo[2];
 
@@ -138,8 +138,14 @@ int rsa_verify_hash_ex(const unsigned char *sig,      unsigned long siglen,
        goto bail_2;
     }
 
+    if ((err = der_length_sequence(siginfo, 2, &reallen)) != CRYPT_OK) {
+	    XFREE(out);
+	    goto bail_2;
+    }
+
     /* test OID */
-    if ((digestinfo[0].size == hash_descriptor[hash_idx].OIDlen) &&
+    if ((reallen == outlen) &&
+        (digestinfo[0].size == hash_descriptor[hash_idx]->OIDlen) &&
         (XMEMCMP(digestinfo[0].data, hash_descriptor[hash_idx].OID, sizeof(unsigned long) * hash_descriptor[hash_idx].OIDlen) == 0) &&
         (siginfo[1].size == hashlen) &&
         (XMEMCMP(siginfo[1].data, hash, hashlen) == 0)) {


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in dep/StormLib/src/libtomcrypt/src/pk/rsa/rsa_verify_hash.c which was cloned from OP-TEE/optee_os but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2016-6129.

### Proposed Fix
Apply the same patch as the one in OP-TEE/optee_os to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2016-6129
https://github.com/OP-TEE/optee_os/commit/30d13250c390c4f56adefdcd3b64b7cc672f9fe2