### PR TITLE
Add "Disables" to Instances that are not done, updated teleports and update bash file

### DIFF
--- a/sql/updates/auth/create_sql.sh
+++ b/sql/updates/auth/create_sql.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+unamestr=`uname`
+echo "--" > "$CUR_PATH/$filename" && echo "File created: $filename";
+if [[ "$unamestr" == 'Darwin' ]]; then
+   datecmd='gdate'
+else
+   datecmd='date'
+fi
+
+CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" && pwd )"
+FOLDER_NAME=$(basename "$CUR_PATH")
+DATE_STR=$($datecmd +%Y_%m_%d)
+
+idx=0
+while : ; do
+    filename="${DATE_STR}_${FOLDER_NAME}_$(printf '%02d' $idx).sql"
+    if [[ ! -e "$CUR_PATH/$filename" ]]; then
+        break
+    fi
+    idx=$((idx+1))
+done
+
+echo "--" > "$CUR_PATH/$filename" && echo "File created: $filename"

--- a/sql/updates/characters/create_sql.sh
+++ b/sql/updates/characters/create_sql.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+unamestr=`uname`
+echo "--" > "$CUR_PATH/$filename" && echo "File created: $filename";
+if [[ "$unamestr" == 'Darwin' ]]; then
+   datecmd='gdate'
+else
+   datecmd='date'
+fi
+
+CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" && pwd )"
+FOLDER_NAME=$(basename "$CUR_PATH")
+DATE_STR=$($datecmd +%Y_%m_%d)
+
+idx=0
+while : ; do
+    filename="${DATE_STR}_${FOLDER_NAME}_$(printf '%02d' $idx).sql"
+    if [[ ! -e "$CUR_PATH/$filename" ]]; then
+        break
+    fi
+    idx=$((idx+1))
+done
+
+echo "--" > "$CUR_PATH/$filename" && echo "File created: $filename"

--- a/sql/updates/world/2026-01-29_world_00.sql
+++ b/sql/updates/world/2026-01-29_world_00.sql
@@ -1,0 +1,14 @@
+DELETE FROM `disables` WHERE `sourceType` = 2 AND `entry` IN (1008, 1009, 1098, 1011);
+INSERT INTO `disables` (`sourceType`, `entry`, `flags`, `params_0`, `params_1`, `comment`) VALUES
+(2, 1008, 63, '', '', 'Disabled Raid: Mogu shan Vaults [ALL DIFFICULTIES] - WIP'),
+(2, 1009, 63, '', '', 'Disabled Raid: Heart of Fear [ALL DIFFICULTIES] - WIP'),
+(2, 1098, 63, '', '', 'Disabled Raid: Throne of Thunder [ALL DIFFICULTIES] - WIP'),
+(2, 1011, 3, '', '', 'Disabled Dungeon: Siege of Niuzao Temple [ALL DIFFICULTIES] - WIP');
+
+UPDATE `game_tele` SET `position_x` = 964.450989, `position_y` = -2454.360107, `position_z` = 180.233551, `orientation` = 80.12928 WHERE `ID` = 1003; -- Jade Serpent Temple (updates from the sky to infront of the temple).
+
+UPDATE `game_tele` SET `position_x` = 1426.476929, `position_y` = 5083.146973, `position_z` = 131.158401, `orientation` = 80.12928 WHERE `ID` = 1024; -- Siege Of Niuzao Temple (updates from the outside to infront of the entrance in the hollowed tree).
+
+DELETE FROM `game_tele` WHERE `id`= 1527;
+INSERT INTO `game_tele` (`id`, `position_x`, `position_y`, `position_z`, `orientation`, `map`, `name`) VALUES
+(1527, 683.242, 2079.95, 371.711, 0.0201836, 870, 'GateOfTheSettingSun');

--- a/sql/updates/world/create_sql.sh
+++ b/sql/updates/world/create_sql.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+unamestr=`uname`
+echo "--" > "$CUR_PATH/$filename" && echo "File created: $filename";
+if [[ "$unamestr" == 'Darwin' ]]; then
+   datecmd='gdate'
+else
+   datecmd='date'
+fi
+
+CUR_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" && pwd )"
+FOLDER_NAME=$(basename "$CUR_PATH")
+DATE_STR=$($datecmd +%Y_%m_%d)
+
+idx=0
+while : ; do
+    filename="${DATE_STR}_${FOLDER_NAME}_$(printf '%02d' $idx).sql"
+    if [[ ! -e "$CUR_PATH/$filename" ]]; then
+        break
+    fi
+    idx=$((idx+1))
+done
+
+echo "--" > "$CUR_PATH/$filename" && echo "File created: $filename"


### PR DESCRIPTION
Instances Disabled (all difficulites):
- Mogu shan Vaults (Raid)
- Heart of Fear (Raid)
- Throne of Thunder (Raid)
- Siege of Niuzao Temple (Dungeon)

All disables were tested but LFG / LFR / Flex, and challenge currently not implemnted as disable flag, the purpose the disables is that, they are completly empty, so disalbing and only allowing users with GM ON to enter

Updated Teleports
- Jade Serpent Templete (from the sky to the gate / instance entrance)
- Siege of Niuzao Template (from the bottom of the tree to the entrance).

Added Teleport
- Gate of The Setting Sun

All the teleports were tested.

Addition to each "updates" folder now there's a create_sql.sh

When ran will create a file based on current date

YYYY_MM_DD_folderName_XY.sql


2026_01_29_world_00.sql
2026_01_29_world_01.sql
2026_01_29_world_02.sql
etc...