### PR TITLE
Fix: seed the global RNG (frand/rand_chance/etc.) so chance-based rolls work

### DIFF
--- a/src/server/shared/Utilities/Util.cpp
+++ b/src/server/shared/Utilities/Util.cpp
@@ -11,32 +11,43 @@
 #include "Util.h"
 
 #include <cstdarg>
+#include <random>
 
-static CRandomSFMT& SfmtRand()
+// The global RNG behind frand/rand_norm/rand_chance/rand32 was a thread_local
+// CRandomSFMT built with its empty default constructor (CRandomSFMT() {}), which
+// never seeds the generator. As a static/thread_local (zero-initialized) object
+// the SFMT state stays all-zero, so Random() always returns 0.0. That makes
+// rand_chance() == 0 and roll_chance_f(chance) (= chance > rand_chance()) always
+// true, so every chance-based roll succeeds (e.g. creatures dropping their whole
+// loot table). Seeding the existing CRandomSFMT via CRandomSFMT(seed) is not an
+// option here because CRandomSFMT::RandomInit is defined in sfmt.cpp and the SFMT
+// library is not linked into worldserver/authserver (unresolved external). Use a
+// properly seeded std::mt19937 instead (distinct seed per thread).
+static std::mt19937& RandEngine()
 {
-    static thread_local CRandomSFMT sfmtRand;
-    return sfmtRand;
+    static thread_local std::mt19937 engine(std::random_device{}() ^ uint32(time(nullptr)));
+    return engine;
 }
 
 float frand(float min, float max)
 {
     ASSERT(max >= min);
-    return float(SfmtRand().Random() * (max - min) + min);
+    return std::uniform_real_distribution<float>(min, max)(RandEngine());
 }
 
 int32 rand32()
 {
-    return int32(SfmtRand().BRandom());
+    return int32(RandEngine()());
 }
 
 double rand_norm(void)
 {
-    return SfmtRand().Random();
+    return std::uniform_real_distribution<double>(0.0, 1.0)(RandEngine());
 }
 
 double rand_chance(void)
 {
-    return SfmtRand().Random() * 100.0;
+    return std::uniform_real_distribution<double>(0.0, 100.0)(RandEngine());
 }
 
 Tokenizer::Tokenizer(const std::string& src, const char sep, uint32 vectorReserve)


### PR DESCRIPTION
## Problem

The global RNG behind `frand` / `rand_norm` / `rand_chance` / `rand32` (`src/server/shared/Utilities/Util.cpp`) is a `thread_local CRandomSFMT` built with the empty default constructor `CRandomSFMT() {}` (`dep/SFMT/sfmt.h`), which never seeds the generator.

Because it is a zero-initialized `static`/`thread_local` object, the SFMT state stays all-zero, so `Random()` always returns `0.0`. Therefore `rand_chance()` is always `0` and `roll_chance_f(chance)` (= `chance > rand_chance()`) is **always true** — every chance-based roll succeeds.

The most visible symptom is loot: creatures drop their **entire** loot table (hitting the 16-item cap), which also crowds quest items out of the loot window so collect-from-mob quests look broken. Every other consumer of these helpers is affected as well.

## Why not simply seed the existing CRandomSFMT

`CRandomSFMT::RandomInit` is defined in `dep/SFMT/sfmt.cpp`, but the SFMT library is not linked into `worldserver`/`authserver`, so calling a seeding constructor produces an unresolved external (LNK2019). Only the (unseeded) default constructor plus the inline `Random()`/`BRandom()` are used today.

## Fix

Replace the unseeded `CRandomSFMT` with a properly seeded `std::mt19937` (one engine per thread, seeded from `std::random_device` XOR `time`). Single-file change, no build-system changes.