### PR TITLE
Fix creature level 0 under SKYFIRE_DEBUG and divide-by-zero in random container helpers.

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -2829,7 +2829,7 @@ Unit* Unit::GetNextRandomRaidMemberOrPet(float radius)
     if (nearMembers.empty())
         return NULL;
 
-    uint32 randTarget = std::rand() % (nearMembers.size() - 1);
+    uint32 randTarget = std::rand() % nearMembers.size();
     return nearMembers[randTarget];
 }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -458,8 +458,8 @@ void ObjectMgr::LoadCreatureTemplates()
         creatureTemplate.SubName = fields[11].GetString();
         creatureTemplate.IconName = fields[12].GetString();
         creatureTemplate.GossipMenuId = fields[13].GetUInt32();
-        creatureTemplate.minlevel = fields[14].GetInt8();
-        creatureTemplate.maxlevel = fields[15].GetInt8();
+        creatureTemplate.minlevel = uint8(fields[14].GetInt16());
+        creatureTemplate.maxlevel = uint8(fields[15].GetInt16());
         creatureTemplate.expansion = uint32(fields[16].GetInt16());
         creatureTemplate.expansionUnknown = uint32(fields[17].GetUInt16());
         creatureTemplate.faction_A = uint32(fields[18].GetUInt16());

--- a/src/server/shared/Containers.h
+++ b/src/server/shared/Containers.h
@@ -23,7 +23,7 @@ namespace Skyfire
             while (list_size > size)
             {
                 typename std::list<T>::iterator itr = list.begin();
-                std::advance(itr, std::rand() % (list_size - 1));
+                std::advance(itr, std::rand() % list_size);
                 list.erase(itr);
                 --list_size;
             }
@@ -48,7 +48,7 @@ namespace Skyfire
         template <class C> typename C::value_type const& SelectRandomContainerElement(C const& container)
         {
             typename C::const_iterator it = container.begin();
-            std::advance(it, std::rand() % (container.size() - 1));
+            std::advance(it, std::rand() % container.size());
             return *it;
         }
 


### PR DESCRIPTION
- Fix INT_DIVIDE_BY_ZERO when loot/random helpers pick from a single-element container (SelectRandomContainerElement, RandomResizeList, GetNextRandomRaidMemberOrPet).

- Fix all creatures spawning at level 0 with ~1–2 HP when built with WITH_COREDEBUG=ON (SKYFIRE_DEBUG): creature_template.minlevel/maxlevel are smallint in the DB but were read with GetInt8(), which returns 0 for non-tinyint columns in debug builds.