### PR TITLE
Allow .setskill to learn skills the player does not have yet.

### DIFF
--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -1342,14 +1342,9 @@ public:
 
         std::string tNameLink = handler->GetNameLink(target);
 
-        if (!target->GetSkillValue(skill))
-        {
-            handler->PSendSysMessage(LANG_SET_SKILL_ERROR, tNameLink.c_str(), skill, skillLine->name);
-            handler->SetSentErrorMessage(true);
-            return false;
-        }
-
         uint16 max = maxPureSkill ? atol(maxPureSkill) : target->GetPureMaxSkillValue(skill);
+        if (!max)
+            max = target->GetMaxSkillValueForLevel();
 
         if (level <= 0 || level > max || max <= 0)
             return false;


### PR DESCRIPTION
- Remove the early check that blocked .setskill when the target did not already have the skill

- Default max skill to GetMaxSkillValueForLevel() when learning a new skill without an explicit max