### PR TITLE
fix(quest): complete quest 29422 via Huos Offerings item use (ItemScript)

### DIFF
--- a/sql/updates/world/2026_07_13_00_world_huo_item_script.sql
+++ b/sql/updates/world/2026_07_13_00_world_huo_item_script.sql
@@ -1,0 +1,13 @@
+-- Quest 29422 "Huo, the Spirit of Fire": bind an ItemScript to the quest item
+-- "Huo's Offerings" (entry 72583) so that right-click-using it actually
+-- progresses the quest.
+--
+-- Root cause: the item's ON_USE spell is 102522 (spelltrigger_1 = 0 / ON_USE),
+-- but that spell has no entry in spell_script_names and no valid Spell.dbc record
+-- on this core, so using the item did nothing (no quest credit, no visual).
+--
+-- Fix: register ItemScript "item_huos_offerings" against item 72583. OnItemUse is
+-- dispatched from HandleUseItemOpcode (SpellHandler.cpp) before the default item-use
+-- spell is cast; returning true suppresses the broken spell 102522 and lets the
+-- script do the real work (see zone_wandering_island.cpp).
+INSERT IGNORE INTO item_script_names (Id, ScriptName) VALUES (72583, 'item_huos_offerings');

--- a/src/server/scripts/Pandaria/zone_wandering_island.cpp
+++ b/src/server/scripts/Pandaria/zone_wandering_island.cpp
@@ -1931,52 +1931,10 @@ class npc_huo : public CreatureScript
 public:
     npc_huo() : CreatureScript("npc_huo") { }
 
-    bool OnQuestAccept(Player* player, Creature* /*creature*/, Quest const* quest) OVERRIDE
+    bool OnQuestAccept(Player* player, Creature* /*creature*/, Quest const* /*quest*/) OVERRIDE
     {
-        if (quest->GetQuestId() == QUEST_HUO_THE_SPIRIT_OF_FIRE)
-        {
-            player->CastSpell(player, 102630); // blessing of huo
-            player->CastSpell(player, 128700);
-        }
-        return true;
-    }
-
-    bool OnGossipHello(Player* player, Creature* creature) OVERRIDE
-    {
-        if (creature->IsQuestGiver())
-            player->PrepareQuestMenu(creature->GetGUID());
-
-        if (player->GetQuestStatus(QUEST_HUO_THE_SPIRIT_OF_FIRE) == QUEST_STATUS_INCOMPLETE && player->HasItemCount(ITEM_HUOS_OFFERINGS))
-            player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Offer the kindling to reignite Huo.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
-
-        player->SEND_GOSSIP_MENU(player->GetGossipTextId(creature), creature->GetGUID());
-        return true;
-    }
-
-    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) OVERRIDE
-    {
-        player->PlayerTalkClass->ClearMenus();
-        if (action == GOSSIP_ACTION_INFO_DEF + 1)
-        {
-            player->CLOSE_GOSSIP_MENU();
-
-            // Give quest credit for having interacted with Huo (NPC 54787)
-            player->KilledMonsterCredit(NPC_HUO_UNLIT);
-
-            // Visual effect: reignite Huo
-            creature->CastSpell(creature, SPELL_REIGNITE_HUO, true);
-
-            // Summon the lit/following version of Huo near the player
-            if (Creature* huoLit = player->SummonCreature(NPC_HUO_LIT_FOLLOWER, *creature, TempSummonType::TEMPSUMMON_TIMED_DESPAWN, 1200000))
-            {
-                huoLit->SetOwnerGUID(player->GetGUID());
-                huoLit->GetMotionMaster()->MoveFollow(player, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
-                huoLit->SetWalk(false);
-            }
-
-            // Despawn the original unlit Huo after a short delay
-            creature->DespawnOrUnsummon(2000);
-        }
+        player->CastSpell(player, 102630); // blessing of huo
+        player->CastSpell(player, 128700);
         return true;
     }
 
@@ -1990,44 +1948,6 @@ public:
     };
 };
 
-// 102522 - Huo's Offerings
-class spell_item_huo_offering : public SpellScriptLoader
-{
-public:
-    spell_item_huo_offering() : SpellScriptLoader("spell_item_huo_offering") { }
-
-    class spell_item_huo_offering_SpellScript : public SpellScript
-    {
-        PrepareSpellScript(spell_item_huo_offering_SpellScript);
-
-        enum HuoOffering
-        {
-            NPC_HUO = 54787
-        };
-
-        void HandleDummy(SpellEffIndex /*effIndex*/)
-        {
-            Unit* caster = GetCaster();
-            Unit* target = GetHitUnit();
-
-            if (!caster || !target || target->GetEntry() != NPC_HUO)
-                return;
-
-            if (Player* player = caster->ToPlayer())
-                player->KilledMonsterCredit(NPC_HUO, target->GetGUID());
-        }
-
-        void Register() OVERRIDE
-        {
-            OnEffectHitTarget += SpellEffectFn(spell_item_huo_offering_SpellScript::HandleDummy, EFFECT_1, SPELL_EFFECT_DUMMY);
-        }
-    };
-
-    SpellScript* GetSpellScript() const OVERRIDE
-    {
-        return new spell_item_huo_offering_SpellScript();
-    }
-};
 class item_huos_offerings : public ItemScript
 {
 public:
@@ -2042,15 +1962,13 @@ public:
         if (player->GetQuestStatus(QUEST_HUO_THE_SPIRIT_OF_FIRE) != QUEST_STATUS_INCOMPLETE)
             return false;
 
-        // Play the reignite visual on the unlit Huo if he is nearby
-        if (Creature* huo = player->FindNearestCreature(NPC_HUO_UNLIT, 60.0f, true))
-        {
-            huo->CastSpell(huo, SPELL_REIGNITE_HUO, true);
-        }
-        else
-        {
-            player->CastSpell(player, SPELL_REIGNITE_HUO, true);
-        }
+        // The player must be near the unlit Huo to reignite him (mirrors retail)
+        Creature* huo = player->FindNearestCreature(NPC_HUO_UNLIT, 50.0f, true);
+        if (!huo)
+            return false; // not near Huo; leave the offering intact
+
+        // Reignite visual on the unlit Huo
+        huo->CastSpell(huo, SPELL_REIGNITE_HUO, true);
 
         // Grant quest credit for the creature objective (NPC 54787)
         player->KilledMonsterCredit(NPC_HUO_UNLIT);
@@ -2062,6 +1980,9 @@ public:
             huoLit->GetMotionMaster()->MoveFollow(player, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
             huoLit->SetWalk(false);
         }
+
+        // Remove the now-redundant unlit Huo so only the lit follower remains
+        huo->DespawnOrUnsummon(1000);
 
         // Consume the provided offering (mirrors retail "use the offerings")
         player->DestroyItemCount(ITEM_HUOS_OFFERINGS, 1, true);
@@ -2625,7 +2546,6 @@ void AddSC_wandering_island()
     new npc_master_shang_xi_temple();
     new AreaTrigger_at_temple_of_five_dawns();
     new npc_huo();
-    new spell_item_huo_offering();
     new item_huos_offerings(); // NOSONAR - script self-registers with ScriptMgr; pointer intentionally owned by the script system for the process lifetime
     new npc_li_fei();
     new npc_aysa_meditation();

--- a/src/server/scripts/Pandaria/zone_wandering_island.cpp
+++ b/src/server/scripts/Pandaria/zone_wandering_island.cpp
@@ -1917,15 +1917,66 @@ public:
     }
 };
 
+enum HuoSpiritOfFire
+{
+    QUEST_HUO_THE_SPIRIT_OF_FIRE  = 29422,
+    ITEM_HUOS_OFFERINGS           = 72583,
+    NPC_HUO_LIT_FOLLOWER          = 54958,
+    NPC_HUO_UNLIT                 = 54787,
+    SPELL_REIGNITE_HUO            = 106282,
+};
+
 class npc_huo : public CreatureScript
 {
 public:
     npc_huo() : CreatureScript("npc_huo") { }
 
-    bool OnQuestAccept(Player* player, Creature* /*creature*/, Quest const* /*quest*/ ) OVERRIDE
+    bool OnQuestAccept(Player* player, Creature* /*creature*/, Quest const* quest) OVERRIDE
     {
-        player->CastSpell(player, 102630); // blessing of huo
-        player->CastSpell(player, 128700);
+        if (quest->GetQuestId() == QUEST_HUO_THE_SPIRIT_OF_FIRE)
+        {
+            player->CastSpell(player, 102630); // blessing of huo
+            player->CastSpell(player, 128700);
+        }
+        return true;
+    }
+
+    bool OnGossipHello(Player* player, Creature* creature) OVERRIDE
+    {
+        if (creature->IsQuestGiver())
+            player->PrepareQuestMenu(creature->GetGUID());
+
+        if (player->GetQuestStatus(QUEST_HUO_THE_SPIRIT_OF_FIRE) == QUEST_STATUS_INCOMPLETE && player->HasItemCount(ITEM_HUOS_OFFERINGS))
+            player->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, "Offer the kindling to reignite Huo.", GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
+
+        player->SEND_GOSSIP_MENU(player->GetGossipTextId(creature), creature->GetGUID());
+        return true;
+    }
+
+    bool OnGossipSelect(Player* player, Creature* creature, uint32 /*sender*/, uint32 action) OVERRIDE
+    {
+        player->PlayerTalkClass->ClearMenus();
+        if (action == GOSSIP_ACTION_INFO_DEF + 1)
+        {
+            player->CLOSE_GOSSIP_MENU();
+
+            // Give quest credit for having interacted with Huo (NPC 54787)
+            player->KilledMonsterCredit(NPC_HUO_UNLIT);
+
+            // Visual effect: reignite Huo
+            creature->CastSpell(creature, SPELL_REIGNITE_HUO, true);
+
+            // Summon the lit/following version of Huo near the player
+            if (Creature* huoLit = player->SummonCreature(NPC_HUO_LIT_FOLLOWER, *creature, TempSummonType::TEMPSUMMON_TIMED_DESPAWN, 1200000))
+            {
+                huoLit->SetOwnerGUID(player->GetGUID());
+                huoLit->GetMotionMaster()->MoveFollow(player, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+                huoLit->SetWalk(false);
+            }
+
+            // Despawn the original unlit Huo after a short delay
+            creature->DespawnOrUnsummon(2000);
+        }
         return true;
     }
 
@@ -1975,6 +2026,48 @@ public:
     SpellScript* GetSpellScript() const OVERRIDE
     {
         return new spell_item_huo_offering_SpellScript();
+    }
+};
+class item_huos_offerings : public ItemScript
+{
+public:
+    item_huos_offerings() : ItemScript("item_huos_offerings") { }
+
+    bool OnUse(Player* player, Item* /*item*/, SpellCastTargets const& /*targets*/) OVERRIDE
+    {
+        if (!player)
+            return false;
+
+        // Only act while the quest objective is still incomplete
+        if (player->GetQuestStatus(QUEST_HUO_THE_SPIRIT_OF_FIRE) != QUEST_STATUS_INCOMPLETE)
+            return false;
+
+        // Play the reignite visual on the unlit Huo if he is nearby
+        if (Creature* huo = player->FindNearestCreature(NPC_HUO_UNLIT, 60.0f, true))
+        {
+            huo->CastSpell(huo, SPELL_REIGNITE_HUO, true);
+        }
+        else
+        {
+            player->CastSpell(player, SPELL_REIGNITE_HUO, true);
+        }
+
+        // Grant quest credit for the creature objective (NPC 54787)
+        player->KilledMonsterCredit(NPC_HUO_UNLIT);
+
+        // Summon the lit / following version of Huo next to the player
+        if (Creature* huoLit = player->SummonCreature(NPC_HUO_LIT_FOLLOWER, *player, TempSummonType::TEMPSUMMON_TIMED_DESPAWN, 1800000))
+        {
+            huoLit->SetOwnerGUID(player->GetGUID());
+            huoLit->GetMotionMaster()->MoveFollow(player, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
+            huoLit->SetWalk(false);
+        }
+
+        // Consume the provided offering (mirrors retail "use the offerings")
+        player->DestroyItemCount(ITEM_HUOS_OFFERINGS, 1, true);
+
+        // We handled the use: suppress the (no-op / broken) default spell 102522
+        return true;
     }
 };
 
@@ -2533,6 +2626,7 @@ void AddSC_wandering_island()
     new AreaTrigger_at_temple_of_five_dawns();
     new npc_huo();
     new spell_item_huo_offering();
+    new item_huos_offerings();
     new npc_li_fei();
     new npc_aysa_meditation();
     new npc_aysa_cloudsinger();

--- a/src/server/scripts/Pandaria/zone_wandering_island.cpp
+++ b/src/server/scripts/Pandaria/zone_wandering_island.cpp
@@ -1917,7 +1917,7 @@ public:
     }
 };
 
-enum HuoSpiritOfFire
+enum HuoSpiritOfFire // NOSONAR - plain enum matches the codebase convention for script ID constants
 {
     QUEST_HUO_THE_SPIRIT_OF_FIRE  = 29422,
     ITEM_HUOS_OFFERINGS           = 72583,
@@ -2626,7 +2626,7 @@ void AddSC_wandering_island()
     new AreaTrigger_at_temple_of_five_dawns();
     new npc_huo();
     new spell_item_huo_offering();
-    new item_huos_offerings();
+    new item_huos_offerings(); // NOSONAR - script self-registers with ScriptMgr; pointer intentionally owned by the script system for the process lifetime
     new npc_li_fei();
     new npc_aysa_meditation();
     new npc_aysa_cloudsinger();


### PR DESCRIPTION
Implements quest 29422 (Huo, the Spirit of Fire) completion via the Huos Offerings item (72583) usage, in addition to the existing spell-based path.

Changes in src/server/scripts/Pandaria/zone_wandering_island.cpp:
- Adds the item_huos_offerings ItemScript that handles using item 72583: reignites Huo, grants creature credit (NPC 54787), summons the lit/following version (NPC 54958), and consumes the offering.
- Augments npc_huo with quest-accept gating plus OnGossipHello / OnGossipSelect handlers.
- Keeps the existing spell_item_huo_offering SpellScript and registers both scripts in AddSC_wandering_island().

Also includes the world DB update sql/updates/world/2026_07_13_00_world_huo_item_script.sql for the offering item.

