### PR TITLE
Fix unreachable outcomes in two holiday event RNG rolls

### DIFF
--- a/src/server/scripts/Spells/spell_holiday.cpp
+++ b/src/server/scripts/Spells/spell_holiday.cpp
@@ -140,7 +140,7 @@ public:
             {
                 uint8 gender = target->getGender();
                 uint32 spellId = SPELL_TRICK_BUFF;
-                switch (std::rand() % 5)
+                switch (std::rand() % 6)
                 {
                 case 1:
                     spellId = gender ? SPELL_LEPER_GNOME_COSTUME_FEMALE : SPELL_LEPER_GNOME_COSTUME_MALE;
@@ -357,7 +357,7 @@ public:
                     if (target->HasAura(spells[i]))
                         return;
 
-                target->CastSpell(target, spells[std::rand() % 3], true);
+                target->CastSpell(target, spells[std::rand() % 4], true);
             }
         }
 


### PR DESCRIPTION
Fixes #1271

`src/server/scripts/Spells/spell_holiday.cpp` had two `std::rand() %` ranges that didn't match the number of possible outcomes:

- Hallow's End Trick: `std::rand() % 5` only produces 0-4, so `case 5` (Skeleton Costume) could never be selected out of the 6 possible outcomes.
- PX-238 Winter Wondervolt: `std::rand() % 3` only produces indices 0-2 into the 4-element `spells` array, so the fourth transform could never be selected.

Widened both ranges to match: `% 5` -> `% 6`, `% 3` -> `% 4`.